### PR TITLE
fix: [#1375] Microsoft.Bot.Components.AdaptiveCards - OnDataQuery trigger doesn't work as expected

### DIFF
--- a/packages/AdaptiveCards/Triggers/OnDataQuery.cs
+++ b/packages/AdaptiveCards/Triggers/OnDataQuery.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Bot.Components.AdaptiveCards
             // Filter to only invoked Action.Execute activities
             var expression = Expression.AndExpression(
                 base.CreateExpression(),
-                Expression.Parse($"{TurnPath.Activity}.name == 'adaptiveCard/action'"),
-                Expression.Parse($"{TurnPath.Activity}.value.action.type == 'Data.Query'"));
+                Expression.Parse($"{TurnPath.Activity}.name == 'application/search'"));
 
             // Add optional verb constraint
             if (!string.IsNullOrEmpty(this.Dataset))


### PR DESCRIPTION
Fixes # 1375
#minor

### Purpose

This PR updates the _OnDataQuery_ trigger and the _SendDataQueryResponse_ action of the AdaptiveCards component, to check for the correct activity name when receiving an invoke activity.
It also creates the search Response Data to send as the body of the InvokeResponse.

### Changes

- Updated _OnDataQuery_ and _SendDataQueryResponse_ to consider `application/search` as the activity name of the invoke activity.
- Updated _SendDataQueryResponse_ adding the creation of the `searchResponseData` to send as the body of the InvokeResponse activity.

### Tests

These images show the _OnDataQuery_ trigger being fired and the data returned by the _SendDataQueryResponse_ shown in the card.
![image](https://user-images.githubusercontent.com/44245136/200042600-aa7f9832-7776-4d42-ba82-38a489a9f968.png)

