### PR TITLE
[#1160] Generated bots can't run in dotnet 5.0 - Migrate Generators to NET6

### DIFF
--- a/build/yaml/pipelines/generator-bot-adaptive.yml
+++ b/build/yaml/pipelines/generator-bot-adaptive.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/generator-bot-core-assistant.yml
+++ b/build/yaml/pipelines/generator-bot-core-assistant.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/generator-bot-core-language.yml
+++ b/build/yaml/pipelines/generator-bot-core-language.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/generator-bot-empty.yml
+++ b/build/yaml/pipelines/generator-bot-empty.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/generator-bot-enterprise-assistant.yml
+++ b/build/yaml/pipelines/generator-bot-enterprise-assistant.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/generator-bot-enterprise-calendar.yml
+++ b/build/yaml/pipelines/generator-bot-enterprise-calendar.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/generator-bot-enterprise-people.yml
+++ b/build/yaml/pipelines/generator-bot-enterprise-people.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/generators/generator-bot-adaptive/generators/app/index.js
+++ b/generators/generator-bot-adaptive/generators/app/index.js
@@ -197,7 +197,7 @@ module.exports = class extends BaseGenerator {
             appSettings.runtime.command = `func start --script-root ${path.join(
               'bin',
               'Debug',
-              'netcoreapp3.1'
+              'net6.0'
             )}`;
             break;
           default:

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
@@ -11,14 +11,14 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.22" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" /><%- packageReferences %>
   </ItemGroup>
   <ItemGroup>
     <Content Update="local.settings.json">

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>
@@ -10,7 +10,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="<%= sdkVersion %>" /><%- packageReferences %>

--- a/generators/generator-bot-adaptive/test/dotnet-functions.test.js
+++ b/generators/generator-bot-adaptive/test/dotnet-functions.test.js
@@ -90,7 +90,7 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
           command: `func start --script-root ${path.join(
             'bin',
             'Debug',
-            'netcoreapp3.1'
+            'net6.0'
           )}`,
           key: `adaptive-runtime-${platform}-${integration}`,
         },


### PR DESCRIPTION
Addresses # 1160
#minor

### Purpose
This PR migrates the bot generators to `NET6` as done for the SDK samples. 
Also, it upgrades the `AzureFunctionsVersion to 4` as Azure will stop supporting version 3 of the runtime soon ([more info](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-csharp)).
Finally, it updates the `vmImage` in the yamls that execute the generators.

### Changes
- Change netcoreapp3.1 with net6.0 in the base generator template.
- Upgrade `Microsoft.AspNetCore.Mvc.NewtonsoftJson` references to version 6.0.7.
- Upgrade `Microsoft.NET.Sdk.Functions` reference to version 4.1.3.
- Upgrade `AzureFunctionsVersion` from 3 to 4.
- Update the `vmImage` in the yamls that execute the generators.

### Tests
Here we can see some of the generated bots working after the changes:
![image](https://user-images.githubusercontent.com/44245136/205137620-2a8b893c-7c09-4c44-8040-f5f1b4bb9503.png)
![image](https://user-images.githubusercontent.com/44245136/205137649-8504173c-26ea-4370-a525-139355de1708.png)

