### PR TITLE
[#1160] Generated bots can't run in dotnet 5.0 - Migrate Skills to NET6

### DIFF
--- a/build/yaml/pipelines/adaptivecards.yml
+++ b/build/yaml/pipelines/adaptivecards.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/calendar.yml
+++ b/build/yaml/pipelines/calendar.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/graph.yml
+++ b/build/yaml/pipelines/graph.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/helpandcancel.yml
+++ b/build/yaml/pipelines/helpandcancel.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/people.yml
+++ b/build/yaml/pipelines/people.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/starter-pipeline.yml
+++ b/build/yaml/pipelines/starter-pipeline.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/teams-js.yml
+++ b/build/yaml/pipelines/teams-js.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/teams.yml
+++ b/build/yaml/pipelines/teams.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/telephony.yml
+++ b/build/yaml/pipelines/telephony.yml
@@ -3,7 +3,7 @@ trigger: none # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 pool:
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/welcome.yml
+++ b/build/yaml/pipelines/welcome.yml
@@ -3,7 +3,7 @@ trigger: none  # ci trigger is set in ADO # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO # pr trigger is set in ADO
 
 pool: 
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/templates/dotnet-build-test-steps.yml
+++ b/build/yaml/templates/dotnet-build-test-steps.yml
@@ -8,7 +8,12 @@ steps:
   displayName: 'Use .Net Core sdk 3.1.x'
   inputs:
     version: 3.1.x
-    
+
+- task: UseDotNet@2
+  displayName: 'Use .Net 6.0.x'
+  inputs:
+    version: 6.0.x
+
 - task: DotNetCoreCLI@2
   displayName: 'Run `dotnet restore`'
   inputs:

--- a/skills/csharp/calendarskill/CalendarSkill.csproj
+++ b/skills/csharp/calendarskill/CalendarSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>2bdd896c-393e-47c4-b6b9-a47238550b83</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Apis.Calendar.v3" Version="1.40.2.1620" />
     <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />    
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Search" Version="10.0.1" />

--- a/skills/csharp/calendarskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/calendarskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/emailskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/emailskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/emailskill/EmailSkill.csproj
+++ b/skills/csharp/emailskill/EmailSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>3383fcc5-4017-4e0a-9103-68603b68fe1d</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Apis" Version="1.40.2" />
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.40.2.1613" />
     <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/pointofinterestskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/pointofinterestskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/pointofinterestskill/PointOfInterestSkill.csproj
+++ b/skills/csharp/pointofinterestskill/PointOfInterestSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>302ba8d8-1f97-40c2-843e-ecf0a2805cf7</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
@@ -10,7 +10,7 @@
   <ItemGroup />
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/shared/SkillServiceLibrary/SkillServiceLibrary.csproj
+++ b/skills/csharp/shared/SkillServiceLibrary/SkillServiceLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/csharp/tests/SkillServiceLibrary.Fakes/SkillServiceLibrary.Fakes.csproj
+++ b/skills/csharp/tests/SkillServiceLibrary.Fakes/SkillServiceLibrary.Fakes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/csharp/tests/SkillServiceLibrary.Tests/SkillServiceLibrary.Tests.csproj
+++ b/skills/csharp/tests/SkillServiceLibrary.Tests/SkillServiceLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/skills/csharp/tests/automotiveskill.tests/AutomotiveSkill.Tests.csproj
+++ b/skills/csharp/tests/automotiveskill.tests/AutomotiveSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <NoWarn>NU1701</NoWarn>

--- a/skills/csharp/tests/calendarskill.tests/CalendarSkill.Tests.csproj
+++ b/skills/csharp/tests/calendarskill.tests/CalendarSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/emailskill.tests/EmailSkill.Tests.csproj
+++ b/skills/csharp/tests/emailskill.tests/EmailSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/pointofinterestskill.tests/PointOfInterestSkill.Tests.csproj
+++ b/skills/csharp/tests/pointofinterestskill.tests/PointOfInterestSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/todoskill.tests/ToDoSkill.Tests.csproj
+++ b/skills/csharp/tests/todoskill.tests/ToDoSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/todoskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/todoskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/todoskill/ToDoSkill.csproj
+++ b/skills/csharp/todoskill/ToDoSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>d8c5f2ea-e759-4038-8a4b-17e0f81e8a46</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/declarative/Calendar/Calendar/Calendar.csproj
+++ b/skills/declarative/Calendar/Calendar/Calendar.csproj
@@ -1,7 +1,7 @@
 ﻿
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <UserSecretsId>7971aa8f-bc9a-432f-961e-687e2f46537e</UserSecretsId>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
   </ItemGroup>
   <ItemGroup>

--- a/skills/declarative/Calendar/Calendar/scripts/deploy.ps1
+++ b/skills/declarative/Calendar/Calendar/scripts/deploy.ps1
@@ -57,7 +57,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\Release\netcoreapp3.1')
+$publishFolder = $(Join-Path $projFolder 'bin\Release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 # Copy bot files to running folder

--- a/skills/declarative/People/People/People.csproj
+++ b/skills/declarative/People/People/People.csproj
@@ -1,7 +1,7 @@
 ﻿
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <UserSecretsId>66c24573-8ba1-4c8c-8a20-18dbbab26e3a</UserSecretsId>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.17.1" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.17.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/tests/unit/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.Tests.csproj
+++ b/tests/unit/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.Tests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp21'">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
+++ b/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
+++ b/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
+++ b/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses # 1160
#minor

### Purpose
This PR migrates the skills projects to `NET6`. 
Also, it upgrades the `AzureFunctionsVersion to 4` as Azure will stop supporting version 3 of the runtime soon ([more info](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-csharp)).
Finally, it updates the `vmImage` in the yamls that build and test the skills.

### Changes
- Change netcoreapp3.1 with net6.0 in all skill projects and test projects.
- Upgrade `Microsoft.AspNetCore.Mvc.NewtonsoftJson` references to version 6.0.7.
- Update the `vmImage` in the yamls that build and test the skills.

### Tests
Here we can see the unit tests passing after the changes:
![image](https://user-images.githubusercontent.com/44245136/205138820-fa5252e3-3a20-4214-92fa-e879b7b69176.png)
