### PR TITLE
[#1160] Generated bots can't run in dotnet 5.0 - Migrate Experimental to NET6

### DIFF
--- a/skills/csharp/experimental/automotiveskill/AutomotiveSkill.csproj
+++ b/skills/csharp/experimental/automotiveskill/AutomotiveSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>6a3184c3-074e-45b9-ad93-eceb8268ec01</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/experimental/automotiveskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/automotiveskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/bingsearchskill/BingSearchSkill.csproj
+++ b/skills/csharp/experimental/bingsearchskill/BingSearchSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dce3ac16-dce5-4fd3-b97a-0f23791e65fc</UserSecretsId>
   </PropertyGroup>
 
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.EntitySearch" Version="2.0.0" />

--- a/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/eventskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/eventskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/eventskill/EventSkill.csproj
+++ b/skills/csharp/experimental/eventskill/EventSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <UserSecretsId>12ed3ad7-66e5-4160-b86c-aff9da5cf4b6</UserSecretsId>
   </PropertyGroup>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/hospitalityskill/HospitalitySkill.csproj
+++ b/skills/csharp/experimental/hospitalityskill/HospitalitySkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <UserSecretsId>a1b79856-3ffb-4825-807a-2dd1be342920</UserSecretsId>
   </PropertyGroup>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
     <PackageReference Include="Bot.Builder.Community.Adapters.Google" Version="4.6.4-beta0056" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/experimental/itsmskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/itsmskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/itsmskill/ITSMSkill.csproj
+++ b/skills/csharp/experimental/itsmskill/ITSMSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/experimental/musicskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/musicskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/musicskill/MusicSkill.csproj
+++ b/skills/csharp/experimental/musicskill/MusicSkill.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />

--- a/skills/csharp/experimental/newsskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/newsskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/newsskill/NewsSkill.csproj
+++ b/skills/csharp/experimental/newsskill/NewsSkill.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.1" />

--- a/skills/csharp/experimental/phoneskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/phoneskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/phoneskill/PhoneSkill.csproj
+++ b/skills/csharp/experimental/phoneskill/PhoneSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <Platforms>x64</Platforms>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Apis" Version="1.36.1" />
     <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.1" />

--- a/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/restaurantbookingskill/RestaurantBookingSkill.csproj
+++ b/skills/csharp/experimental/restaurantbookingskill/RestaurantBookingSkill.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>6a3184c3-074e-45b9-ad93-eceb8268ec01</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.1" />
     <PackageReference Include="Microsoft.Recognizers.Text" Version="1.2.9" />

--- a/skills/csharp/experimental/weatherskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/weatherskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/weatherskill/WeatherSkill.csproj
+++ b/skills/csharp/experimental/weatherskill/WeatherSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <UserSecretsId>bf895f98-5182-4f36-a89d-d52cdde1a45c</UserSecretsId>
   </PropertyGroup>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />

--- a/skills/csharp/tests/hospitalityskill.tests/HospitalitySkill.Tests.csproj
+++ b/skills/csharp/tests/hospitalityskill.tests/HospitalitySkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/skills/csharp/tests/itsmskill.tests/ITSMSkill.Tests.csproj
+++ b/skills/csharp/tests/itsmskill.tests/ITSMSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/musicskill.Tests/MusicSkill.Tests.csproj
+++ b/skills/csharp/tests/musicskill.Tests/MusicSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/phoneskill.tests/PhoneSkill.Tests.csproj
+++ b/skills/csharp/tests/phoneskill.tests/PhoneSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
     <Platforms>x64</Platforms>

--- a/skills/csharp/tests/weatherSkill.tests/WeatherSkill.Tests.csproj
+++ b/skills/csharp/tests/weatherSkill.tests/WeatherSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Addresses # 1160
#minor

### Purpose
This PR migrates the experimental skills projects to `NET6`. 

### Changes
- Change netcoreapp3.1 with net6.0 in all experimental skill projects and test projects.
- Upgrade `Microsoft.AspNetCore.Mvc.NewtonsoftJson` references to version 6.0.7.

### Tests
Here we can see the unit tests passing after the changes:
![image](https://user-images.githubusercontent.com/44245136/205138820-fa5252e3-3a20-4214-92fa-e879b7b69176.png)
