### PR TITLE
[#1160] Generated bots can't run in dotnet 5.0 - Migrate Functional Tests to NET6

### DIFF
--- a/build/arm/template-function-dotnet-bot-resources.json
+++ b/build/arm/template-function-dotnet-bot-resources.json
@@ -66,8 +66,9 @@
             "[concat('Microsoft.Web/Sites/', parameters('botName'))]"
           ],
           "properties": {
-            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_EXTENSION_VERSION": "~4",
             "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+            "netFrameworkVersion": "v6.0",
             "APPINSIGHTS_INSTRUMENTATIONKEY": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]",
             "MicrosoftAppId": "[parameters('appId')]",
             "MicrosoftAppPassword": "[parameters('appSecret')]"

--- a/build/arm/template-function-js-bot-resources.json
+++ b/build/arm/template-function-js-bot-resources.json
@@ -66,7 +66,7 @@
             "[concat('Microsoft.Web/Sites/', parameters('botName'))]"
           ],
           "properties": {
-            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_EXTENSION_VERSION": "~4",
             "FUNCTIONS_WORKER_RUNTIME": "node",
             "WEBSITE_NODE_DEFAULT_VERSION": "~14",
             "APPINSIGHTS_INSTRUMENTATIONKEY": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]",

--- a/build/yaml/functional/cleanupResources/cleanupResources.yml
+++ b/build/yaml/functional/cleanupResources/cleanupResources.yml
@@ -25,7 +25,7 @@ variables:
   NugetSecurityAnalysisWarningLevel: warn # Workaround: Sets the warning level of injected nuget security analysis to raise a warning in logs and set status to green. Visit https://aka.ms/nugetmultifeed for more details.
 
 pool:
-  vmImage: "windows-2019"
+  vmImage: "windows-2022"
 
 stages:
 - stage: "Delete_DotNet_Resource_Group"

--- a/build/yaml/functional/deployBotResources/deployBotResources.yml
+++ b/build/yaml/functional/deployBotResources/deployBotResources.yml
@@ -7,7 +7,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: "windows-2019"
+  vmImage: "windows-2022"
 
 parameters:
   - name: dependenciesVersionDotNetHosts
@@ -88,7 +88,7 @@ stages:
 
         - id: "Prepare_JSGroup"
           name: "$(INTERNALRESOURCEGROUPNAME)-JS"
-          displayName: "Prepare JS's Resource Group"          
+          displayName: "Prepare JS's Resource Group"
 
 # DotNet
   - template: dotnet/deploy.yml
@@ -113,7 +113,7 @@ stages:
             generator: 'generators/generator-bot-empty'
             integration: "webapp"
             name: "EmptyBotDotNetWebApp"
-            netCoreVersion: "3.1.x"
+            netCoreVersion: "6.0.x"
             platform: "dotnet"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetHosts }}
@@ -129,7 +129,7 @@ stages:
             generator: 'generators/generator-bot-empty'
             integration: "functions"
             name: "EmptyBotDotNetFunctions"
-            netCoreVersion: "3.1.x"
+            netCoreVersion: "6.0.x"
             platform: "dotnet"
           dependency:
             registry: ${{ parameters.dependenciesRegistryDotNetHosts }}

--- a/build/yaml/functional/sharedResources/createSharedResources.yml
+++ b/build/yaml/functional/sharedResources/createSharedResources.yml
@@ -7,7 +7,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: "windows-2019"
+  vmImage: "windows-2022"
 
 variables:
   ## Azure Resources (Define these variables in Azure)

--- a/build/yaml/functional/testScenarios/runScenario.yml
+++ b/build/yaml/functional/testScenarios/runScenario.yml
@@ -62,9 +62,9 @@ stages:
                 scenario: "${{ scenario.name }}"
 
             - task: UseDotNet@2
-              displayName: "Use .Net Core sdk 3.1.x"
+              displayName: "Use .Net 6.0.x"
               inputs:
-                version: 3.1.x
+                version: 6.0.x
 
             - task: DotNetCoreCLI@2
               displayName: "Build"

--- a/build/yaml/functional/testScenarios/runTestScenarios.yml
+++ b/build/yaml/functional/testScenarios/runTestScenarios.yml
@@ -31,7 +31,7 @@ variables:
   NugetSecurityAnalysisWarningLevel: warn # Workaround: Sets the warning level of injected nuget security analysis to raise a warning in logs and set status to green. Visit https://aka.ms/nugetmultifeed for more details.
 
 pool:
-  vmImage: "windows-2019"
+  vmImage: "windows-2022"
 
 stages:
   - stage: "Download_Variables"

--- a/build/yaml/pipelines/functionaltests.yml
+++ b/build/yaml/pipelines/functionaltests.yml
@@ -15,9 +15,9 @@ variables:
 steps:
 
 - task: UseDotNet@2
-  displayName: "Use .Net Core sdk 3.1.x"
+  displayName: "Use .Net 6.0.x"
   inputs:
-    version: 3.1.x
+    version: 6.0.x
 
 - task: NuGetToolInstaller@1
   displayName: "Use NuGet"

--- a/tests/functional/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/tests/functional/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>btc</AssemblyName>
   </PropertyGroup>

--- a/tests/functional/Tests/ComponentsFunctionalTests/ComponentsFunctionalTests.csproj
+++ b/tests/functional/Tests/ComponentsFunctionalTests/ComponentsFunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/functional/Tests/TranscriptTestRunnerTests/TranscriptTestRunnerTests.csproj
+++ b/tests/functional/Tests/TranscriptTestRunnerTests/TranscriptTestRunnerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Fixes # 1160
#minor

### Purpose
This PR migrates the Functional Tests projects `NET6`.
Also, it updates the arm templates of the azure functions to use version 4 of the runtime as Azure will stop supporting version 3 soon ([more info](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-csharp)).
Finally, it updates the `vmImage` and references to NetCore 3.1 in the functional tests yamls.

### Changes
- Change netcoreapp3.1 with net6.0 in the functional tests projects.
- Update azure functions arm templates to version 4 of the runtime.
- Update the vmImage in the functional tests yamls.

### Tests
Here we can see the functional tests pipelines successfully executed:
![image](https://user-images.githubusercontent.com/44245136/205140962-0deb3eee-510b-4482-867c-bfb832419b5d.png)
