### PR TITLE
[#1445] Component Governance security vulnerability for shelljs 0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tar": "6.1.13",
     "@azure/identity": "3.1.2",
     "@azure/ms-rest-js": "2.6.4",
-    "@xmldom/xmldom": "0.8.6"
+    "@xmldom/xmldom": "0.8.6",
+    "shelljs": "^0.8.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9449,16 +9449,16 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"shelljs@npm:^0.8.0, shelljs@npm:^0.8.4":
-  version: 0.8.4
-  resolution: "shelljs@npm:0.8.4"
+"shelljs@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
   dependencies:
     glob: ^7.0.0
     interpret: ^1.0.0
     rechoir: ^0.6.2
   bin:
     shjs: bin/shjs
-  checksum: bdf68e3c2a8a6d191dde3be2800bfcfd688c126344ccaf6cf7024cdaf824d0d3523b8e514cd52264f739cbabd2b0569637dd5a8183377347225af918e03ff5dc
+  checksum: 6ab7ecababcfcaced2131df582378d0a234cfc7336b041616986c76e8bf7877855359f4481e78f041b21a2d610b3920ce156473b4de2bc88e8039eb3278affba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes # 1445

### Purpose
This PR upgrades the [shelljs](https://www.npmjs.com/package/shelljs) dependency from 0.8.4 to 0.8.5 due to the [CVE-2022-0144](https://github.com/advisories/GHSA-4rq4-32rv-6wp6) security vulnerability.

### Changes
- Upgrade shelljs from 0.8.4 to 0.8.5.