### PR TITLE
[#1444] Component Governance security vulnerability for qs 6.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tar": "6.1.13",
     "@azure/identity": "3.1.2",
     "@azure/ms-rest-js": "2.6.4",
-    "@xmldom/xmldom": "0.8.6"
+    "@xmldom/xmldom": "0.8.6",
+    "qs": "^6.5.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8668,10 +8668,12 @@ fsevents@^1.2.3:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.5.2":
-  version: 6.5.2
-  resolution: "qs@npm:6.5.2"
-  checksum: fa0410eff2c05ce3328e11f82db4015e7819c986ee056d6b62b06ae112f4929af09ea3b879ca168ff9f0338f50972bba487ad0e46c879e42bfaf63c3c2ea7f09
+"qs@npm:^6.5.3":
+  version: 6.11.0
+  resolution: "qs@npm:6.11.0"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 03213666774bd72b859ca7273d3bb4e42892605df613c180124ad12c1ef8c66b2516836589dc6514b875bce4939c8805e139a88b8400e2118a46223d0ce21b9e
   languageName: node
   linkType: hard
 
@@ -9466,6 +9468,17 @@ resolve@1.1.7:
   version: 0.1.1
   resolution: "shellwords@npm:0.1.1"
   checksum: 3559ff550917ece921d252edf42eb54827540e9676e537137ace236df8f9b78e48c542ae0b3f8876fea0faf5826c97629d5b8cb9ac7dee287260e9804fb8132c
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "side-channel@npm:1.0.4"
+  dependencies:
+    call-bind: ^1.0.0
+    get-intrinsic: ^1.0.2
+    object-inspect: ^1.9.0
+  checksum: 84258ce3edb1ad35810ca17eccd52fd504b5d4da59447a6829cfd1ae8e3cff97b7df2a14f9a45b7aaa3b507ded95626cf20a500735d3b797e9ffb1eba3cfa9e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes # 1444

### Purpose
This PR upgrades the [qs](https://www.npmjs.com/package/qs) dependency from 6.5.2 to 6.5.3 due to the [CVE-2022-24999](https://github.com/advisories/GHSA-hrpp-h998-j3pp) security vulnerability.

### Changes
- Upgrade qs from 6.5.2 to 6.5.3.