### PR TITLE
[#1441,#1442] Component Governance security vulnerabilities for moment 2.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tar": "6.1.13",
     "@azure/identity": "3.1.2",
     "@azure/ms-rest-js": "2.6.4",
-    "@xmldom/xmldom": "0.8.6"
+    "@xmldom/xmldom": "0.8.6",
+    "moment": "^2.29.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7527,10 +7527,10 @@ fsevents@^1.2.3:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.15.1, moment@npm:^2.24.0":
-  version: 2.29.1
-  resolution: "moment@npm:2.29.1"
-  checksum: 86729013febf7160de5b93da69273dd304d674b0224f9544b3abd09a87671ddd2cdd57598261ce57588910d63747ffd5590965e83c790d8bf327083c0e0a06e0
+"moment@npm:^2.29.4":
+  version: 2.29.4
+  resolution: "moment@npm:2.29.4"
+  checksum: 5aa949ddcfc8dee4984123410cc0cd504caa6ef691bd191a527a1de67529895dcc8a8342cd67fb1953ae87172ea701bb957cea6d30abf0677ca9c62e834a5b5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes # 1441
Fixes # 1442

### Purpose
This PR upgrades the [moment](https://www.npmjs.com/package/moment) dependency from 2.29.1 to 2.29.4 due to the [CVE-2022-24785](https://github.com/advisories/GHSA-8hfj-j24r-96c4) security vulnerability.

### Changes
- Upgrade moment from 2.29.1 to 2.29.4.