### PR TITLE
[#1434] Component Governance security vulnerability for minimist 1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tar": "6.1.13",
     "@azure/identity": "3.1.2",
     "@azure/ms-rest-js": "2.6.4",
-    "@xmldom/xmldom": "0.8.6"
+    "@xmldom/xmldom": "0.8.6",
+    "minimist": "^1.2.7"
   }
 }

--- a/skills/declarative/Calendar/Calendar/scripts/package.json
+++ b/skills/declarative/Calendar/Calendar/scripts/package.json
@@ -16,7 +16,7 @@
         "@types/fs-extra": "^8.1.0",
         "chalk": "^4.0.0",
         "fs-extra": "^8.1.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.7",
         "ora": "^4.0.4",
         "request-promise": "^4.2.5"
     }

--- a/skills/declarative/People/People/Scripts/package.json
+++ b/skills/declarative/People/People/Scripts/package.json
@@ -16,7 +16,7 @@
         "@types/fs-extra": "^8.1.0",
         "chalk": "^4.0.0",
         "fs-extra": "^8.1.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.7",
         "ora": "^4.0.4",
         "request-promise": "^4.2.5"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7330,10 +7330,10 @@ fsevents@^1.2.3:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.1, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: b77b8590147a4e217ff34266236bc39de23b52e6e33054076991ff674c7397a1380a7bde11111916f16f003a94aaa7e4f3d92595a32189644ff607fabc65a5b6
+"minimist@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "minimist@npm:1.2.7"
+  checksum: 16e2fda9eaded0629c4928518ee172a2749d5feece07588e56df37eaba08fff859d0d1f0925b0462c4299a8784b36fd035851acc5007a5f8c1939a98da27a1c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes # 1434

### Purpose
This PR upgrades the [minimist](https://www.npmjs.com/package/minimist) dependency from 1.2.5 to 1.2.7 due to the [CVE-2021-44906](https://github.com/advisories/GHSA-xvch-5gv4-984h) security vulnerability.

### Changes
- Upgrade minimist from 1.2.5 to 1.2.7.