### PR TITLE
[#1463] PR's failing lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "resolutions": {
     "adal-node": "0.2.4",
     "axios": "1.2.1",
-    "async": "2.6.4",
+    "async@2": "^2.6.4",
+    "async@3": "^3.2.4",
     "cross-fetch": "3.1.5",
     "node-fetch": "2.6.7",
     "tar": "6.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,7 +1522,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:2.6.4":
+"async@npm:0.9.x":
+  version: 0.9.2
+  resolution: "async@npm:0.9.2"
+  checksum: 78c0aad8add0b84ccf9bde90d20a9cd20146e3734a4c9ac9bfb3a30d1b7df12b7d95c13119af825a89480210c02f7ffee38ac07c13ac43abd6636691b982b591
+  languageName: node
+  linkType: hard
+
+"async@npm:^2.1.4, async@npm:^2.6.0, async@npm:^2.6.2, async@npm:^2.6.3":
   version: 2.6.4
   resolution: "async@npm:2.6.4"
   dependencies:


### PR DESCRIPTION
Fixes # 1463

### Purpose

This PR adds the async versions corresponding to the libraries that depend on it according to their versions that have the vulnerability issue fixed.

### Changes

-Add async version 2.6.4 in package.json for the libraries that use async 2.x 
-Add async version 3.2.4 in package.json for the libraries that use async 3.x 

### Tests
The following image shows the result of the pipeline that generates the yarn.lock working successfully
![image](https://user-images.githubusercontent.com/122501764/218167835-49d36ba1-debf-4237-be72-7e54781e699e.png)




